### PR TITLE
kernel-build: Bail out if script fails

### DIFF
--- a/kernel.sh
+++ b/kernel.sh
@@ -20,6 +20,9 @@
 
 #Kernel building script
 
+# Bail out if script fails
+set -e
+
 # Function to show an informational message
 msg() {
 	echo


### PR DESCRIPTION
* On drone CI, script does not return an exit code even if the kernel compile fails.
* This allows the script to bail out if the script fails.