### PR TITLE
kernel: switched to a better way to print out distro name

### DIFF
--- a/kernel.sh
+++ b/kernel.sh
@@ -134,7 +134,7 @@ LOG_DEBUG=0
 # set KBUILD_BUILD_VERSION and KBUILD_BUILD_HOST and CI_BRANCH
 
 ## Set defaults first
-DISTRO=$(cat /etc/issue)
+DISTRO=$(source /etc/os-release && echo ${NAME})
 KBUILD_BUILD_HOST=$(uname -a | awk '{print $2}')
 CI_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 TERM=xterm


### PR DESCRIPTION
This way doesn't print out extra stuff like /r (\l) in distro name. 