### PR TITLE
kernel: added building modules support

### DIFF
--- a/kernel.sh
+++ b/kernel.sh
@@ -71,6 +71,9 @@ DEFCONFIG=vendor/violet-perf_defconfig
 # 'clang' or 'gcc'
 COMPILER=clang
 
+# Build modules. 0 = NO | 1 = YES
+MODULES=0
+
 # Specify linker.
 # 'ld.lld'(default)
 LINKER=ld.lld
@@ -310,6 +313,17 @@ build_kernel() {
 		LD=$LINKER \
 		V=$VERBOSE \
 		"${MAKE[@]}" 2>&1 | tee error.log
+	if [ $MODULES = "1" ]
+	then
+	    msg "|| Started Compiling Modules ||"
+	    make -j"$PROCS" O=out \
+		 "${MAKE[@]}" modules_prepare
+	    make -j"$PROCS" O=out \
+		 "${MAKE[@]}" modules INSTALL_MOD_PATH="$KERNEL_DIR"/out/modules
+	    make -j"$PROCS" O=out \
+		 "${MAKE[@]}" modules_install INSTALL_MOD_PATH="$KERNEL_DIR"/out/modules
+	    find "$KERNEL_DIR"/out/modules -type f -iname '*.ko' -exec cp {} AnyKernel3/modules/system/lib/modules/ \;
+	fi
 
 		BUILD_END=$(date +"%s")
 		DIFF=$((BUILD_END - BUILD_START))


### PR DESCRIPTION
This adds support to build modules in an easy and painless way following
how the script is structured.

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>