### PR TITLE
kernel: Switch to Markdown for formatting `tg_post_build`

### DIFF
--- a/kernel.sh
+++ b/kernel.sh
@@ -252,8 +252,8 @@ tg_post_build() {
 	curl --progress-bar -F document=@"$1" "$BOT_BUILD_URL" \
 	-F chat_id="$CHATID"  \
 	-F "disable_web_page_preview=true" \
-	-F "parse_mode=html" \
-	-F caption="$2 | <b>MD5 Checksum : </b><code>$MD5CHECK</code>"
+	-F "parse_mode=Markdown" \
+	-F caption="$2 | *MD5 Checksum : *\`$MD5CHECK\`"
 }
 
 ##----------------------------------------------------------##
@@ -345,7 +345,7 @@ build_kernel() {
 			else
 			if [ "$PTTG" = 1 ]
  			then
-				tg_post_build "error.log" "<b>Build failed to compile after $((DIFF / 60)) minute(s) and $((DIFF % 60)) seconds</b>"
+				tg_post_build "error.log" "*Build failed to compile after $((DIFF / 60)) minute(s) and $((DIFF % 60)) seconds*"
 			fi
 		fi
 	


### PR DESCRIPTION
Formatting with HTML tends to throw the below error:-
curl: (26) Failed to open/read local data from file/application

As I have tested, Markdown seems to work fine for this case without having any issues.

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>